### PR TITLE
Version code comparison should be 'less than', not 'not equal'

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -147,7 +147,7 @@ class GPlaycli(object):
             store_version_code = doc.details.appDetails.versionCode
 
             # Compare
-            if apk_version_code != "" and int(apk_version_code) != int(store_version_code) and int(
+            if apk_version_code != "" and int(apk_version_code) < int(store_version_code) and int(
                     store_version_code) != 0:
                 # Add to the download list
                 list_apks_to_update.append([packagename, filename, int(apk_version_code), int(store_version_code)])


### PR DESCRIPTION
```
$ aapt dump xmltree com.facebook.katana.apk AndroidManifest.xml | grep versionName
    A: android:versionName(0x0101021c)="120.0.0.0.31" (Raw: "120.0.0.0.31")

$ gplaycli -v -y -u .
Using credentials to connect to API
Checking apks ...
Analyzing com.facebook.katana
The following applications will be updated :
com.facebook.katana.apk Version : 54586640 -> 54394138

Do you agree?
Downloading ...
1/1 com.facebook.katana
Download complete
Updated: com.facebook.katana

$ aapt dump xmltree com.facebook.katana.apk AndroidManifest.xml | grep versionName
    A: android:versionName(0x0101021c)="118.0.0.22.79" (Raw: "118.0.0.22.79")
```