### PR TITLE
Conditionally use keyring to store the password

### DIFF
--- a/credentials.conf
+++ b/credentials.conf
@@ -1,6 +1,7 @@
 [Credentials]
 gmail_address=
 gmail_password=
+#keyring_service=gplaycli
 android_ID=3d716411bf8bc802
 language=fr_FR
 token=True


### PR DESCRIPTION
Hello,

There's a python package called keyring, that knows how to semi-safely store credentials on a wide variety of encrypted stores.

https://github.com/jaraco/keyring

I added a small patch to conditionally try to use it and thought others might find it useful.

enabling the code path is triggered by setting a service name in the credentials file.