### PR TITLE
Fixed bug to allow search to return more than 10 items

### DIFF
--- a/ext_libs/googleplay_api/googleplay.py
+++ b/ext_libs/googleplay_api/googleplay.py
@@ -200,7 +200,16 @@ class GooglePlayAPI(object):
             path += "&o=%d" % int(offset)
 
         message = self.executeRequestApi2(path)
-        return message.payload.searchResponse
+
+        messagenext = message
+        allmessages = message
+        for i in range(0, int(nb_results), 10):
+            pathnext = messagenext.payload.searchResponse.doc[0].containerMetadata.nextPageUrl
+            messagenext = self.executeRequestApi2(pathnext)
+            allmessages.MergeFrom(messagenext)
+
+        
+        return allmessages.payload.searchResponse
 
     def details(self, packageName):
         """Get app details from a package name.

--- a/ext_libs/googleplay_api/googleplay.py
+++ b/ext_libs/googleplay_api/googleplay.py
@@ -194,19 +194,24 @@ class GooglePlayAPI(object):
     def search(self, query, nb_results=None, offset=None):
         """Search for apps."""
         path = "search?c=3&q=%s" % requests.utils.quote(query) # TODO handle categories
-        if (nb_results is not None):
-            path += "&n=%d" % int(nb_results)
         if (offset is not None):
             path += "&o=%d" % int(offset)
 
         message = self.executeRequestApi2(path)
 
+        remaining = int(nb_results) - len(message.payload.searchResponse.doc[0].child)
+
         messagenext = message
         allmessages = message
-        for i in range(0, int(nb_results), 10):
+
+        while remaining > 0:
+            print(remaining)
             pathnext = messagenext.payload.searchResponse.doc[0].containerMetadata.nextPageUrl
             messagenext = self.executeRequestApi2(pathnext)
+            remaining -= len(messagenext.payload.searchResponse.doc[0].child)
             allmessages.MergeFrom(messagenext)
+          
+          
 
         
         return allmessages.payload.searchResponse

--- a/ext_libs/googleplay_api/googleplay.py
+++ b/ext_libs/googleplay_api/googleplay.py
@@ -196,24 +196,15 @@ class GooglePlayAPI(object):
         path = "search?c=3&q=%s" % requests.utils.quote(query) # TODO handle categories
         if (offset is not None):
             path += "&o=%d" % int(offset)
-
         message = self.executeRequestApi2(path)
-
         remaining = int(nb_results) - len(message.payload.searchResponse.doc[0].child)
-
         messagenext = message
         allmessages = message
-
         while remaining > 0:
-            print(remaining)
             pathnext = messagenext.payload.searchResponse.doc[0].containerMetadata.nextPageUrl
             messagenext = self.executeRequestApi2(pathnext)
             remaining -= len(messagenext.payload.searchResponse.doc[0].child)
             allmessages.MergeFrom(messagenext)
-          
-          
-
-        
         return allmessages.payload.searchResponse
 
     def details(self, packageName):

--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -322,9 +322,7 @@ class GPlaycli(object):
 
     def search(self, results_list, search_string, nb_results, free_only=True, include_headers=True):
         results = self.raw_search(results_list, search_string, nb_results)
-        if len(results) > 0:
-            results = results[0].child
-        else:
+        if len(results) < 1:
             print "No result"
             return
         all_results = list()
@@ -333,19 +331,20 @@ class GPlaycli(object):
             col_names = ["Title", "Creator", "Size", "Downloads", "Last Update", "AppID", "Version", "Rating"]
             all_results.append(col_names)
         # Compute results values
-        for result in results:
-            if free_only and result.offer[0].checkoutFlowRequired:  # if not Free to download
-                continue
-            l = [result.title,
-                 result.creator,
-                 self.sizeof_fmt(result.details.appDetails.installationSize),
-                 result.details.appDetails.numDownloads,
-                 result.details.appDetails.uploadDate,
-                 result.docid,
-                 result.details.appDetails.versionCode,
-                 "%.2f" % result.aggregateRating.starRating
-                 ]
-            all_results.append(l)
+        for docs in results:
+            for result in docs.child:
+                if free_only and result.offer[0].checkoutFlowRequired:  # if not Free to download
+                    continue
+                l = [result.title,
+                     result.creator,
+                     self.sizeof_fmt(result.details.appDetails.installationSize),
+                     result.details.appDetails.numDownloads,
+                     result.details.appDetails.uploadDate,
+                     result.docid,
+                     result.details.appDetails.versionCode,
+                     "%.2f" % result.aggregateRating.starRating
+                     ]
+                all_results.append(l)
 
         if self.verbose:
             # Print a nice table

--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -344,7 +344,8 @@ class GPlaycli(object):
                      result.details.appDetails.versionCode,
                      "%.2f" % result.aggregateRating.starRating
                      ]
-                all_results.append(l)
+                if len(all_results) < int(nb_results):
+                    all_results.append(l)
 
         if self.verbose:
             # Print a nice table

--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -344,7 +344,7 @@ class GPlaycli(object):
                      result.details.appDetails.versionCode,
                      "%.2f" % result.aggregateRating.starRating
                      ]
-                if len(all_results) < int(nb_results):
+                if len(all_results) < int(nb_results)+1:
                     all_results.append(l)
 
         if self.verbose:


### PR DESCRIPTION
I have been using gplaycli to search and download large numbers of apps from the app store. But recently the search only returns a maximum of 10 items. This pull request makes some quick and shoddy changes to request for the next pages and combine the items together to return more matching applications based on "-n", this breaks API compatibility with googleplay_api though, but that code is not being maintained anymore.