### PR TITLE
Add a default value to the retries field

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -66,7 +66,7 @@ class GPlaycli(object):
                     raise OSError("No configuration file found at %s" % cred_paths_list)
             credentials = tmp_list[0]
 
-        self.configparser = ConfigParser.ConfigParser()
+        self.configparser = ConfigParser.ConfigParser({"retries": "10"})
         self.configparser.read(credentials)
         self.config = dict()
         for key, value in self.configparser.items("Credentials"):


### PR DESCRIPTION
Fixes #82.
If the retries field is not in the configuration file, set a default value to it.
I set it to 10 since it's the default value in credentials.conf you have in the repo.

There is probably a better way to do it through the ConfigParser, but it can do for now I guess :)