### PR TITLE
Fix regression in previous patch

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -227,7 +227,7 @@ class GPlaycli(object):
         # BulkDetails requires only one HTTP request
         # Get APK info from store
         details = playstore_api.bulkDetails(package_bunch)
-        for detail, packagename, apk_version_code in zip(details, package_bunch, version_codes):
+        for detail, packagename, filename, apk_version_code in zip(details, package_bunch, list_of_apks, version_codes):
             store_version_code = detail['versionCode']
 
             # Compare


### PR DESCRIPTION
My previous patch introduced a bug. The filename variable was not set when checking for updates and thus the updates were downloaded to the wrong path.