### PR TITLE
Fix typo

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -250,9 +250,9 @@ class GPlaycli:
 
 			if filename is None:
 				if self.append_version:
-					filename = "%s-v.%s.apk" % (detail['docId'], detail['versionString'])
+					filename = "%s-v.%s.apk" % (detail['docid'], detail['versionString'])
 				else:
-					filename = "%s.apk" % detail['docId']
+					filename = "%s.apk" % detail['docid']
 
 			logger.info("%s / %s %s", 1+position, len(pkg_todownload), packagename)
 


### PR DESCRIPTION
When i tried to download apk file, there was an exeception: 
`  File "/python3.6/site-packages/gplaycli/gplaycli.py", line 255, in download
    filename = "%s.apk" % detail['docId']
KeyError: 'docId'
`

Response from server contains "{'docid': 'com.Seriously.BestFiends', " and etc. So there is typo.