### PR TITLE
setup.py: add a missing '/' to config file install path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='gplaycli',
 			'gplaycli': 'gplaycli',
 		},
 		data_files=[
-			['etc/gplaycli', ['gplaycli.conf']],
+			['/etc/gplaycli', ['gplaycli.conf']],
 		],
 		install_requires=[
 				'matlink-gpapi>=0.4.4.4',


### PR DESCRIPTION
Without this, when running setup.py with --root=/foo, the config file
ends up in /foo/usr/etc/gplaycli instead of /foo/etc/gplaycli. I'm guessing
that $prefix is prepended when there's no leading slash.