### PR TITLE
Fix splits KeyError while downloading

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -287,7 +287,7 @@ class GPlaycli:
 				continue
 
 			additional_data = data_iter['additionalData']
-			splits = data_iter['splits']
+			splits = data_iter.get('splits')
 			total_size = int(data_iter['file']['total_size'])
 			chunk_size = int(data_iter['file']['chunk_size'])
 			try:


### PR DESCRIPTION
Currently downloading will fail with following error:

```
gplaycli --verbose --progress -d com.pushbullet.android
[INFO] GPlayCli version 3.29 [Python3.8.2]
[INFO] Configuration file is /home/guoqiao/git/gplaycli/gplaycli.conf
[INFO] Device is bacon
[INFO] Using credentials to connect to API
[INFO] Using plaintext password
[INFO] 1 / 1 com.pushbullet.android
/usr/local/lib/python3.8/dist-packages/gpapi/googleplay.py:634: RuntimeWarning: Unexpected end-group tag: Not all data was converted
  response = googleplay_pb2.ResponseWrapper.FromString(response.content)
Traceback (most recent call last):
  File "/usr/local/bin/gplaycli", line 11, in <module>
    load_entry_point('gplaycli', 'console_scripts', 'gplaycli')()
  File "/home/guoqiao/git/gplaycli/gplaycli/gplaycli.py", line 659, in main
    cli.download(args.download)
  File "/home/guoqiao/git/gplaycli/gplaycli/hooks.py", line 11, in check_connection
    return function(self, *args, **kwargs)
  File "/home/guoqiao/git/gplaycli/gplaycli/gplaycli.py", line 290, in download
    splits = data_iter['splits']
KeyError: 'splits'
```

Use `get` to avoid dict `KeyError` while `splits` not exists in `data_iter`.

Fixes: https://github.com/matlink/gplaycli/issues/272

Signed-off-by: Qiao Guo <guoqiao@gmail.com>