### PR TITLE
Add more detail to unhandled exceptions

### DIFF
--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -275,7 +275,7 @@ class GPlaycli:
 				unavail_downloads.append((item, exc))
 				continue
 			except Exception as exc:
-				logger.error("Error while downloading %s : %s", packagename, exc)
+				logger.exception("Error while downloading %s", exc_info=exc)
 				failed_downloads.append((item, exc))
 				continue
 

--- a/gplaycli/gplaycli.py
+++ b/gplaycli/gplaycli.py
@@ -275,7 +275,7 @@ class GPlaycli:
 				unavail_downloads.append((item, exc))
 				continue
 			except Exception as exc:
-				logger.exception("Error while downloading %s", exc_info=exc)
+				logger.exception("Error while downloading %s", packagename, exc_info=exc)
 				failed_downloads.append((item, exc))
 				continue
 


### PR DESCRIPTION
Hi,

This is just a small change that made my life easier trying to debug #271, since the catch for `except Exception` is quite broad, and the message printed later doesn't really help you finding what the exception class is, neither where it happened.